### PR TITLE
Allow test-suites to run without JDT

### DIFF
--- a/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/launch/AbstractHaskellLaunchDelegate.java
+++ b/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/launch/AbstractHaskellLaunchDelegate.java
@@ -46,11 +46,6 @@ public abstract class AbstractHaskellLaunchDelegate extends LaunchConfigurationD
         File workingDir = determineWorkingDir( configuration );
         checkCancellation( monitor );
 
-        if (!shouldContinue()) {
-          // The launch cannot continue
-          return;
-        }
-
         IProcess process = createProcess( configuration, mode, launch, loc,
             cmdLine, workingDir );
         if( process != null ) {
@@ -129,10 +124,6 @@ public abstract class AbstractHaskellLaunchDelegate extends LaunchConfigurationD
   protected abstract void preProcessDefinitionCreation(final ILaunchConfiguration configuration,
       final String mode,final ILaunch launch) throws CoreException;
   protected abstract void postProcessFinished();
-
-  protected boolean shouldContinue() {
-    return true;
-  }
 
   private IProcess createProcess( final ILaunchConfiguration configuration,
       final String mode, final ILaunch launch, final IPath location,

--- a/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/launch/TestSuiteHaskellLaunchDelegate.java
+++ b/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/launch/TestSuiteHaskellLaunchDelegate.java
@@ -71,20 +71,30 @@ public class TestSuiteHaskellLaunchDelegate extends
     final File file = new File( fname );
     // final TestSuiteAndSession session = TestSuiteAndSession.parseFile( file );
 
-    Display.getDefault().syncExec( new Runnable() {
+    if (canShowJUnit()) {
+      Display.getDefault().syncExec( new Runnable() {
 
-      public void run() {
-        try {
-          IWorkbenchPage page = PlatformUI.getWorkbench()
-              .getActiveWorkbenchWindow().getActivePage();
-          page.showView( JUNIT_VIEW );
-          // JUnitCorePlugin.getModel().addTestRunSession( session );
-          JUnitModel.importTestRunSession( file );
-        } catch( CoreException e ) {
-          // Do nothing
+        public void run() {
+          try {
+            IWorkbenchPage page = PlatformUI.getWorkbench()
+                .getActiveWorkbenchWindow().getActivePage();
+            page.showView( JUNIT_VIEW );
+            // JUnitCorePlugin.getModel().addTestRunSession( session );
+            JUnitModel.importTestRunSession( file );
+          } catch( CoreException e ) {
+            // Do nothing
+          }
         }
-      }
-    } );
+      } );
+    } else {
+      Display.getCurrent().syncExec( new Runnable() {
+
+        public void run() {
+          MessageDialog.openError( PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+              CoreTexts.jdt_notFound_title, CoreTexts.jdt_notFound_message );
+        }
+      } );
+    }
 
     // Always delete the file at the end
     new File( getFilename() ).delete();
@@ -93,8 +103,7 @@ public class TestSuiteHaskellLaunchDelegate extends
   /* (non-Javadoc)
    * @see net.sf.eclipsefp.haskell.debug.core.internal.launch.AbstractHaskellLaunchDelegate#shouldContinue()
    */
-  @Override
-  protected boolean shouldContinue() {
+  protected boolean canShowJUnit() {
     try {
       // Try to find JDT Core
       this.getClass().getClassLoader().loadClass( "org.eclipse.jdt.core.IJavaProject" ); //$NON-NLS-1$
@@ -105,12 +114,6 @@ public class TestSuiteHaskellLaunchDelegate extends
       // Everything is OK
       return true;
     } catch (Throwable t) {
-      Display.getCurrent().syncExec( new Runnable() {
-        public void run() {
-          MessageDialog.openError( PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
-              CoreTexts.jdt_notFound_title, CoreTexts.jdt_notFound_message );
-        }
-      } );
       return false;
     }
   }

--- a/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/util/coretexts.properties
+++ b/net.sf.eclipsefp.haskell.debug.core/src/net/sf/eclipsefp/haskell/debug/core/internal/util/coretexts.properties
@@ -19,5 +19,6 @@ testSuite_waiting=Running test suite
 profiling_waiting=Getting profiling information
 
 jdt_notFound_title=JDT not found
-jdt_notFound_message=Java Development Tools are not installed in your system, so the JUnit view cannot be launched.\n\
-Check how to install it in http://eclipsefp.github.com/installation.html.
+jdt_notFound_message=Java Development Tools are not installed in your system, so the JUnit view cannot be launched. \
+You can check the test results in the Console view.\n\
+Check how to install the JDT in http://eclipsefp.github.com/installation.html.


### PR DESCRIPTION
This patch implements what you suggested in the last pull request.
