### PR TITLE
Show keywords in Hoogle searches

### DIFF
--- a/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResult.java
+++ b/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResult.java
@@ -36,6 +36,8 @@ public abstract class HoogleResult {
 			return new HoogleResultDeclaration(o);
 		else if (type.equals("constructor"))
 			return new HoogleResultConstructor(o);
+		else if (type.equals("keyword"))
+			return new HoogleResultKeyword(o);
 		else
 			return null;
 	}

--- a/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResultKeyword.java
+++ b/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResultKeyword.java
@@ -1,0 +1,42 @@
+/**
+ * (c) 2012, Alejandro Serrano
+ * Released under the terms of the EPL.
+ */
+package net.sf.eclipsefp.haskell.browser.items;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Represents the information from a keyword returned
+ * by a Hoogle search.
+ * 
+ * @author Alejandro Serrano
+ */
+public class HoogleResultKeyword extends HoogleResult {
+	String keyword;
+
+	public HoogleResultKeyword(String keyword) {
+		setType(HoogleResultType.KEYWORD);
+		this.keyword = keyword;
+	}
+	
+	public HoogleResultKeyword(JSONObject o) throws JSONException {
+		setType(HoogleResultType.KEYWORD);
+		this.keyword = o.getString("name");
+	}
+	
+	public String getKeyword() {
+		return this.keyword;
+	}
+
+	@Override
+	public String getName() {
+		return this.keyword;
+	}
+	
+	@Override
+	public String getCompleteDefinition() {
+		return "keyword " + this.getName();
+	}
+}

--- a/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResultType.java
+++ b/net.sf.eclipsefp.haskell.browser/src/net/sf/eclipsefp/haskell/browser/items/HoogleResultType.java
@@ -13,5 +13,6 @@ public enum HoogleResultType {
 	PACKAGE,
 	MODULE,
 	DECLARATION,
-	CONSTRUCTOR
+	CONSTRUCTOR,
+	KEYWORD
 }

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/util/HtmlUtil.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/util/HtmlUtil.java
@@ -127,6 +127,10 @@ public class HtmlUtil {
     return builder.toString();
   }
 
+  public static String generateKeywordUrl( final String keyword ) {
+    return "http://www.haskell.org/haskellwiki/Keywords#" + keyword;
+  }
+
   public static String generatePackageUrl( final PackageIdentifier item ) {
     if( item.getName().equals( "ghc" ) ) {
       // GHC libraries are a special case

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/util/ImageCache.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/util/ImageCache.java
@@ -26,6 +26,7 @@ public class ImageCache {
   public static Image INSTANCE = HaskellUIImages.getImage( IImageNames.INSTANCE_DECL );
   public static Image FUNCTION = HaskellUIImages.getImage( IImageNames.FUNCTION_BINDING );
   public static Image TYPE = HaskellUIImages.getImage( IImageNames.TYPE_DECL );
+  public static Image KEYWORD = HaskellUIImages.getImage( IImageNames.PATTERN_BINDING );
 
   /**
    * Get the image corresponding to a declaration.

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/views/hoogle/HoogleLabelProvider.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/views/hoogle/HoogleLabelProvider.java
@@ -53,6 +53,8 @@ public class HoogleLabelProvider implements ILabelProvider {
       case DECLARATION:
         Declaration decl = ((HoogleResultDeclaration)result).getDeclaration();
         return ImageCache.getImageForDeclaration( decl.getType() );
+      case KEYWORD:
+        return ImageCache.KEYWORD;
     }
 
     return null;
@@ -70,6 +72,7 @@ public class HoogleLabelProvider implements ILabelProvider {
       switch(result.getType()) {
         case PACKAGE:
         case MODULE:
+        case KEYWORD:
           return result.getName();
         case DECLARATION:
           Declaration decl = ((HoogleResultDeclaration)result).getDeclaration();
@@ -90,6 +93,7 @@ public class HoogleLabelProvider implements ILabelProvider {
         switch(result.getType()) {
           case PACKAGE:
           case MODULE:
+          case KEYWORD:
             return null; // This should not happen
           case DECLARATION:
             HoogleResultDeclaration decl = (HoogleResultDeclaration)result;

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/views/hoogle/HoogleView.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/browser/views/hoogle/HoogleView.java
@@ -281,6 +281,10 @@ public class HoogleView extends ViewPart implements SelectionListener,
     if( result != null ) {
       String text = null;
       switch( result.getType() ) {
+        case KEYWORD:
+          text = HtmlUtil.generateDocument( "keyword "
+              + result.getName(), "" );
+          break;
         case PACKAGE:
           HaskellPackage pkg = ( ( HoogleResultPackage )result ).getPackage();
           text = HtmlUtil.generateDocument( "package "
@@ -336,6 +340,9 @@ public class HoogleView extends ViewPart implements SelectionListener,
 
     String url = null;
     switch( result.getType() ) {
+      case KEYWORD:
+        url = HtmlUtil.generateKeywordUrl( result.getName() );
+        break;
       case PACKAGE:
         HoogleResultPackage pkg = ( HoogleResultPackage )result;
         url = HtmlUtil.generatePackageUrl( pkg.getPackage().getIdentifier() );


### PR DESCRIPTION
I changed scion-browser and EclipseFP so it doesn't ignore keywords, but show them as results.
When a keyword is double-clicked, it will point to http://www.haskell.org/haskellwiki/Keywords.
