### PR TITLE
Added actual version and path info to missing and outdated executable dialogs

### DIFF
--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/InstallExecutableDialog.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/InstallExecutableDialog.java
@@ -29,15 +29,21 @@ import org.eclipse.swt.widgets.Shell;
  *
  */
 public class InstallExecutableDialog extends Dialog {
-  private boolean buildWrapper=true;
-  private boolean scionBrowser=true;
+  protected boolean buildWrapper=true;
+  protected boolean scionBrowser=true;
+  protected String buildWrapperMinVersion="";
+  protected String scionBrowserMinVersion="";
+
   private Button bUser;
   private Button bIgnore;
 
-  public InstallExecutableDialog( final Shell parentShell,final boolean buildWrapper,final boolean scionBrowser ) {
+  public InstallExecutableDialog( final Shell parentShell,final boolean buildWrapper, final String buildWrapperMinVersion,
+                                                          final boolean scionBrowser, final String scionBrowserMinVersion) {
     super( parentShell );
     this.buildWrapper=buildWrapper;
     this.scionBrowser=scionBrowser;
+    this.buildWrapperMinVersion = buildWrapperMinVersion;
+    this.scionBrowserMinVersion = scionBrowserMinVersion;
   }
 
 
@@ -60,6 +66,18 @@ public class InstallExecutableDialog extends Dialog {
     return UITexts.executablesmissing_message2;
   }
 
+  protected String getMessageText(){
+    if (buildWrapper){
+      if (scionBrowser){
+        String[] bindings = {"buildwrapper", buildWrapperMinVersion, "scion-browser", scionBrowserMinVersion};
+        return NLS.bind( getMessage2(), bindings );
+      } else {
+        return NLS.bind( getMessage1(), "buildwrapper", buildWrapperMinVersion);
+      }
+    } else {
+      return NLS.bind( getMessage1(), "scion-browser", scionBrowserMinVersion);
+    }
+  }
 
   @Override
   protected void configureShell( final Shell newShell ) {
@@ -72,18 +90,9 @@ public class InstallExecutableDialog extends Dialog {
   protected Control createDialogArea( final Composite parent ) {
     Composite c=(Composite)super.createDialogArea( parent );
     ((GridLayout)c.getLayout()).numColumns=2;
-    String msg=null;
-    if (buildWrapper){
-      if (scionBrowser){
-        msg=NLS.bind( getMessage2(), "buildwrapper","scion-browser" );
-      } else {
-        msg=NLS.bind( getMessage1(), "buildwrapper");
-      }
-    } else {
-      msg=NLS.bind( getMessage1(), "scion-browser");
-    }
+
     Label l=new Label(c,SWT.NONE);
-    l.setText( msg );
+    l.setText( getMessageText() );
     GridData gd=new GridData(GridData.FILL_HORIZONTAL);
     gd.horizontalSpan=2;
     l.setLayoutData( gd );

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/InstallOutdatedExecutableDialog.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/InstallOutdatedExecutableDialog.java
@@ -7,6 +7,7 @@ package net.sf.eclipsefp.haskell.ui.internal.scion;
 
 import net.sf.eclipsefp.haskell.ui.internal.preferences.IPreferenceConstants;
 import net.sf.eclipsefp.haskell.ui.internal.util.UITexts;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -15,10 +16,19 @@ import org.eclipse.swt.widgets.Shell;
  *
  */
 public class InstallOutdatedExecutableDialog extends InstallExecutableDialog {
+  protected String buildWrapperActualVersion="";
+  protected String buildWrapperPath="";
+  protected String scionBrowserActualVersion="";
+  protected String scionBrowserPath="";
 
   public InstallOutdatedExecutableDialog( final Shell parentShell,
-      final boolean buildWrapper, final boolean scionBrowser ) {
-    super( parentShell, buildWrapper, scionBrowser );
+      final boolean buildWrapper, final String buildWrapperMinVersion, final String buildWrapperActualVersion, final String buildWrapperPath,
+      final boolean scionBrowser, final String scionBrowserMinVersion, final String scionBrowserActualVersion, final String scionBrowserPath ) {
+    super( parentShell, buildWrapper, buildWrapperMinVersion, scionBrowser, scionBrowserMinVersion );
+    this.buildWrapperActualVersion = buildWrapperActualVersion;
+    this.buildWrapperPath = buildWrapperPath;
+    this.scionBrowserActualVersion = scionBrowserActualVersion;
+    this.scionBrowserPath = scionBrowserPath;
   }
 
   @Override
@@ -29,6 +39,23 @@ public class InstallOutdatedExecutableDialog extends InstallExecutableDialog {
   @Override
   protected String getMessage2() {
     return UITexts.executablestoo_old_message2;
+  }
+
+  @Override
+  protected String getMessageText(){
+    if (this.buildWrapper){
+      if (this.scionBrowser){
+        String[] bindings = {"buildwrapper",buildWrapperMinVersion, buildWrapperActualVersion, buildWrapperPath,
+                             "scion-browser",scionBrowserMinVersion, scionBrowserActualVersion, scionBrowserPath};
+        return NLS.bind( getMessage2(), bindings);
+      } else {
+        String[] bindings = {"buildwrapper", buildWrapperMinVersion, buildWrapperActualVersion, buildWrapperPath};
+        return NLS.bind( getMessage1(), bindings);
+      }
+    } else {
+      String[] bindings = {"scion-browser", scionBrowserMinVersion, scionBrowserActualVersion, scionBrowserPath};
+      return NLS.bind( getMessage1(), bindings);
+    }
   }
 
   @Override

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/ScionManager.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/scion/ScionManager.java
@@ -177,7 +177,7 @@ public class ScionManager implements IResourceChangeListener {
           public void run() {
             Shell parent = display.getActiveShell();
 
-            InstallExecutableDialog ied=new InstallExecutableDialog(parent , buildWrapperExecutablePath==null, browserExecutablePath==null );
+            InstallExecutableDialog ied=new InstallExecutableDialog(parent , buildWrapperExecutablePath==null, MINIMUM_BUILDWRAPPER, browserExecutablePath==null, MINIMUM_SCIONBROWSER );
             ied.open();
           }
         });
@@ -200,7 +200,10 @@ public class ScionManager implements IResourceChangeListener {
             public void run() {
               Shell parent = display.getActiveShell();
 
-              InstallOutdatedExecutableDialog ied=new InstallOutdatedExecutableDialog(parent , !buildwrapperVersionOK, !browserVersionOK );
+              InstallOutdatedExecutableDialog ied =
+                  new InstallOutdatedExecutableDialog(parent,
+                                                     !buildwrapperVersionOK, MINIMUM_BUILDWRAPPER, getVersion(buildWrapperExecutablePath,true), buildWrapperExecutablePath.toOSString(),
+                                                     !browserVersionOK, MINIMUM_SCIONBROWSER, getVersion(browserExecutablePath, false), browserExecutablePath.toOSString() );
               ied.open();
             }
           });
@@ -309,19 +312,24 @@ public class ScionManager implements IResourceChangeListener {
     }
   }
 
-  public static boolean checkVersion(final IPath path,final String minimal,final boolean wait){
+  public static String getVersion(final IPath path,final boolean wait){
     if (path!=null){
       try {
-        String currentVersion=ProcessRunner.getExecutableVersion(path.toOSString(),wait);
-        if (currentVersion==null){
-          return false;
-        }
-        return CabalPackageVersion.compare( currentVersion, minimal )>=0;
+        return ProcessRunner.getExecutableVersion(path.toOSString(),wait);
       } catch (IOException ioe){
-        HaskellUIPlugin.log(UITexts.error_checkVersion, ioe);
+        HaskellUIPlugin.log(UITexts.error_getVersion, ioe);
       }
     }
-    return true;
+    return null;
+  }
+
+  public static boolean checkVersion(final IPath path,final String minimal,final boolean wait){
+    String currentVersion=getVersion(path, wait);
+    if (currentVersion==null) {
+      return false;
+    } else {
+      return CabalPackageVersion.compare( currentVersion, minimal )>=0;
+    }
   }
 
 

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/util/UITexts.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/util/UITexts.java
@@ -433,6 +433,7 @@ public final class UITexts extends NLS {
   public static String executablestoo_old_title;
   public static String executablestoo_old_message1;
   public static String executablestoo_old_message2;
+  public static String error_getVersion;
   public static String error_checkVersion;
 
   public static String executablesmissing_title;

--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/util/uitexts.properties
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/util/uitexts.properties
@@ -168,17 +168,18 @@ scionBrowserDoesntExist_title = scion-browser doesn't exist
 scionBrowserDoesntExist_message = The scion-browser executable does not exist:\n\n{0}\n\nPlease check preferences!
 
 executablesmissing_title= Helper Executable(s) missing
-executablesmissing_message1=The helper executable {0} is missing.\nChoose Install to download and install it from Hackage,\nor Cancel to set it up manually in the Haskell Preferences Page.
-executablesmissing_message2=The helper executables {0} and {1} are missing.\nChoose Install to download and install them from Hackage,\nor Cancel to set them up manually in the Haskell Preferences Page.
+executablesmissing_message1=The helper executable {0} (version {1}) is missing.\n\nChoose Install to download and install it from Hackage,\nor Cancel to set it up manually in the Haskell Preferences Page.
+executablesmissing_message2=The helper executables {0} (version {1})\nand {2} (version {3}) are missing.\n\nChoose Install to download and install them from Hackage,\nor Cancel to set them up manually in the Haskell Preferences Page.
 executablesmissing_install=Install
 executablesmissing_user=Install for current user only
 executablesmissing_ignore=Do not ask me again
 
+error_getVersion = Error retrieving executable version
 error_checkVersion = Error checking executable version
 
 executablestoo_old_title= Helper Executable(s) too old
-executablestoo_old_message1=The helper executable {0} is too old.\nChoose Install to download and install it from Hackage,\nor Cancel to set it up manually in the Haskell Preferences Page.
-executablestoo_old_message2=The helper executables {0} and {1} are too old.\nChoose Install to download and install them from Hackage,\nor Cancel to set them up manually in the Haskell Preferences Page.
+executablestoo_old_message1=The version of helper executable {0} at:\n{3}\nis {2}, but at least version {1} is required.\n\nChoose Install to download and install it from Hackage,\nor Cancel to set it up manually in the Haskell Preferences Page.
+executablestoo_old_message2=The version of helper executable {0} at:\n{3}\nis {2}, but at least version {1} is required.\n\nThe version of helper executable {4} at:\n{7}\nis {6}, but at least version {5} is required.\n\nChoose Install to download and install them from Hackage,\nor Cancel to set them up manually in the Haskell Preferences Page.
 
 scionBrowserNotConfigured_title = scion-browser is not configured
 scionBrowserNotConfigured_message = The Scion Browser path is not configured.\n\


### PR DESCRIPTION
Especially during development, this extra information can be helpful to understand what EclipseFP expects exactly.

The meaning of checkVersion has changed slightly, as it now returns false when the path is null. However, this is in line with the way it is used (and also makes more sense.)

The value of wait has been copied from the old checkVersion calls (true for buildwrapper, false for scion-browser). I'm not sure why there is a difference though.
