### PR TITLE
small fix for syntax highlighter in async mode

### DIFF
--- a/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/editors/haskell/HaskellPresentationReconciler.java
+++ b/net.sf.eclipsefp.haskell.ui/src/net/sf/eclipsefp/haskell/ui/internal/editors/haskell/HaskellPresentationReconciler.java
@@ -63,7 +63,8 @@ public class HaskellPresentationReconciler extends PresentationReconciler{
     @Override
     protected IStatus run( final IProgressMonitor arg0 ) {
       final TextPresentation p=HaskellPresentationReconciler.super.createPresentation( damage, document );
-      if (p!=null && viewer!=null && viewer.getTextWidget()!=null && !viewer.getTextWidget().isDisposed()){
+      if (p!=null && viewer!=null && viewer.getTextWidget()!=null && !viewer.getTextWidget().isDisposed() &&
+          !queue.hasPendingJob()){
         viewer.getTextWidget().getDisplay().syncExec( new Runnable(){
           /* (non-Javadoc)
            * @see java.lang.Runnable#run()


### PR DESCRIPTION
when highlighting finishes in a different thread, the source code may
have changed in the mean time, making the tokenization invalid. This can
cause coloring to be applied that's off by a few characters, or even
exceptions if the file has been shortened.

This fix discards the tokenizer result if the file has changed by seeing
if there is another queued highlighter job. When continuously typing, newly
typed characters may not highlight immediately. But on the other hand, this 
actually makes the async-highlight mode usable for me.

Also use the implicit lock in the SingleJobQueue object for
synchronization instead of creating another object.
