### PR TITLE
Please add instructions for building from source using Eclipse 4.2 (Juno)

### DIFF
--- a/net.sf.eclipsefp.haskell.style.test/.classpath
+++ b/net.sf.eclipsefp.haskell.style.test/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/net.sf.eclipsefp.haskell.style"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.swt_3.7.1.v3738a.jar"/>
-	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.swt.win32.win32.x86_3.7.1.v3738a.jar"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.swt"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
The current instructions, in particular the part about installing the BIRT Charting Engine, refer to Eclipse 3.7. I'm using Eclipse 4.2, and there seem to have been some changes in the naming of things, also I'm not sure about possible compatibility issues.

Open questions:
- Searching the BIRT 4.2 update site (http://download.eclipse.org/birt/update-site/4.2) for "chart engine" returns no results. Searching for "chart", then for "engine" shows several confusing choices ("BIRT Chart Framework", "BIRT Chart OSGI Runtime SDK Feature", "BIRT Engine OSGI Runtime SDK Feature", and other permutations of buzzwords). Which items should I install (if any)?
- If BIRT 4.2 is not compatible with building EclipseFP, what combination of installs should I use?
  - Eclipse 3.7 with BIRT Charting Engine 3.7
  - Eclipse 4.2 with BIRT Charting Engine 3.7
  - Any other version(s)?

{-
rant:
I'm not an Eclipse wizard, and neither do I have the intention of becoming one. I just want an IDE for functional programming, and EclipseFP works well (in Eclipse 4.2) for that. I have spent more time trying to fix all kinds of weirdness in Eclipse than I'd care to admit, and in the time it would have taken me to fix them all, I could have easily constructed a complete proof of Fermat's Last Theorem (just joking!)
You get my drift (I hope) :-)
-}
