### PR TITLE
Fix for file locking problem on project deletion

### DIFF
--- a/net.sf.eclipsefp.haskell.buildwrapper/src/net/sf/eclipsefp/haskell/buildwrapper/BWFacade.java
+++ b/net.sf.eclipsefp.haskell.buildwrapper/src/net/sf/eclipsefp/haskell/buildwrapper/BWFacade.java
@@ -483,8 +483,13 @@ public class BWFacade {
 				p.getOutputStream().write(endCommand);
 				try {
 					p.getOutputStream().flush();
-				} catch (IOException ignore){
-					// noop: flush fails if the process closed properly because write flush
+				} catch (IOException ignore) {
+					// noop: flush fails if the process already exited due to write
+				}
+				try {
+					// wait for exit to prevent subsequent file locking issues
+					p.waitFor();
+				} catch (InterruptedException ignore){
 				}
 			} catch (IOException ioe){
 				BuildWrapperPlugin.logError(BWText.process_launch_error, ioe);


### PR DESCRIPTION
This fixes #115. I successfully tested this change on Windows.

Apart from closing all processes before project deletion I also had to change the `BWFacade.endLongRunning()` method slightly to make it blocking. That is, it now waits until the process actually exited.
