### PR TITLE
Replace 'org.junit4' bundle with 'org.junit'

### DIFF
--- a/net.sf.eclipsefp.haskell.core.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.core.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: net.sf.eclipsefp.haskell.core.test
 Bundle-Version: 2.5.0
 Bundle-Vendor: eclipsefp.sourceforge.net
 Require-Bundle: org.easymock;bundle-version="[2.2.0,3.0.0)",
- org.junit4,
+ org.junit;bundle-version="[4.8.0,4.12.0)",
  org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.expressions,

--- a/net.sf.eclipsefp.haskell.debug.ui.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.debug.ui.test/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: net.sf.eclipsefp.haskell.core,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.ui,
- org.junit4,
+ org.junit;bundle-version="[4.8.0,4.12.0)",
  net.sf.eclipsefp.haskell.debug.core;bundle-version="2.6.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/net.sf.eclipsefp.haskell.ghccompiler.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.ghccompiler.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: net.sf.eclipsefp.haskell.ghccompiler.test
 Bundle-Version: 2.2.3
 Bundle-Vendor: eclipsefp.sourceforge.net
 Require-Bundle: org.easymock;bundle-version="[2.2.0,3.0.0)",
- org.junit4,
+ org.junit;bundle-version="[4.8.0,4.12.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  net.sf.eclipsefp.haskell.core,

--- a/net.sf.eclipsefp.haskell.hlint.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.hlint.test/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: HLintTest
 Bundle-SymbolicName: net.sf.eclipsefp.haskell.hlint.test
 Bundle-Version: 2.5.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="[4.8.0,4.12.0)",
  net.sf.eclipsefp.haskell.hlint;bundle-version="2.5.0"
 Export-Package: net.sf.eclipsefp.haskell.hlint

--- a/net.sf.eclipsefp.haskell.scion.client.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.scion.client.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: net.sf.eclipsefp.haskell.scion.client.test
 Bundle-Version: 2.1.1
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.junit4,
+ org.junit;bundle-version="[4.8.0,4.12.0)",
  net.sf.eclipsefp.haskell.util;bundle-version="2.1.1"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-Vendor: eclipsefp.sourceforge.net

--- a/net.sf.eclipsefp.haskell.style.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.style.test/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: StyleTest
 Bundle-SymbolicName: net.sf.eclipsefp.haskell.style.test
 Bundle-Version: 2.6.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="[4.8.0,4.12.0)",
  net.sf.eclipsefp.haskell.style;bundle-version="2.3.1"
 Export-Package: net.sf.eclipsefp.haskell.style

--- a/net.sf.eclipsefp.haskell.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Haskell Test Plug-In
 Bundle-SymbolicName: net.sf.eclipsefp.haskell.test
 Bundle-Version: 2.5.0
 Require-Bundle: net.sf.eclipsefp.haskell.core.test,
- org.junit4,
+ org.junit;bundle-version="[4.8.0,4.12.0)",
  net.sf.eclipsefp.haskell.debug.ui.test;bundle-version="1.106.0",
  net.sf.eclipsefp.haskell.ghccompiler.test;bundle-version="1.106.0",
  net.sf.eclipsefp.haskell.ui.test;bundle-version="1.106.0",

--- a/net.sf.eclipsefp.haskell.ui.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Haskell UI Test Plug-in
 Bundle-SymbolicName: net.sf.eclipsefp.haskell.ui.test
 Bundle-Version: 2.6.1.qualifier
 Bundle-Vendor: eclipsefp.sourceforge.net
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="[4.8.0,4.12.0)",
  org.easymock;bundle-version="[2.2.0,3.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",

--- a/net.sf.eclipsefp.haskell.util.test/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsefp.haskell.util.test/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: net.sf.eclipsefp.haskell.util.test
 Bundle-Version: 2.5.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: net.sf.eclipsefp.haskell.util;bundle-version="2.3.1",
- org.junit4
+ org.junit;bundle-version="[4.8.0,4.12.0)"
 Export-Package: net.sf.eclipsefp.haskell.util


### PR DESCRIPTION
Kepler, unfortunately, removes the 'org.junit4' compatibility bundle.
Thus, the build was broken on Kepler. Replacing the dependency with
'org.junit' and specifying version 4 should allow building on Kepler as
well as maintaining compatibility with earlier versions of Eclipse. The
dependency specifies an inclusive lower bound of 4.8.x to support at
least Eclipse 3.7.

Additionally, several of the manifests had inconsistent line endings, so
their diffs will unfortunately be worthless. Converting them now will
prevent future headaches, though.
