### PR TITLE
Add explicit generic type

### DIFF
--- a/net.sf.eclipsefp.haskell.debug.ui/src/net/sf/eclipsefp/haskell/debug/ui/internal/launch/LaunchUpdater.java
+++ b/net.sf.eclipsefp.haskell.debug.ui/src/net/sf/eclipsefp/haskell/debug/ui/internal/launch/LaunchUpdater.java
@@ -29,7 +29,7 @@ public class LaunchUpdater implements CabalFileChangeListener {
 
            //IInteractiveLaunchOperationDelegate delegate=(IInteractiveLaunchOperationDelegate)cl.loadClass( delegateClass).newInstance();
 
-           List<?> fileNames=c.getAttribute( ILaunchAttributes.FILES, new ArrayList<>() );
+           List<?> fileNames=c.getAttribute( ILaunchAttributes.FILES, new ArrayList<String>() );
            //IFile[] files=new IFile[fileNames.size()];
            List<IFile> files=new ArrayList<>(fileNames.size());
            for(Object o:fileNames){


### PR DESCRIPTION
This helps Eclipse Luna to find the correct overload method.
Fixes error:

```
The method getAttribute(String, boolean) in the type ILaunchConfiguration 
is not applicable for the arguments (String, ArrayList<Object>) 

LaunchUpdater.java  /net.sf.eclipsefp.haskell.debug.ui/src/net/sf/eclipsefp/haskell/debug/ui/internal/launch    
line 32
```
